### PR TITLE
✨ Add a pre-commit hook that verifies commit format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0 # Use the ref you want to point at
+    hooks:
+      - id: check-yaml
+      - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: gitmoji-check
+        name: "Check Gitmoji Commit Messages"
+        entry: scripts/gitmoji-check
+        language: script
+        types: [text]

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
           typstfmt.packages.${system}.default
           pkgs.act
           pkgs.nodePackages_latest.prettier
+          pkgs.pre-commit
         ];
       };
 

--- a/scripts/gitmoji-check
+++ b/scripts/gitmoji-check
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+error=0
+
+while read -r line; do
+    if ! grep -qE '^[\x{1F300}-\x{1F5FF}]+ .+' <<< "$line"; then
+        echo "Invalid commit message: $line"
+        error=1
+    fi
+done < <(git log --format=%B --reverse "$1..HEAD")
+
+exit $error


### PR DESCRIPTION
#### Summary

This will verify that commit messages follow the gitmoji format. 

The hooks can be installed with the following commands:
```sh
pre-commit
pre-commit install
```

#### Checklist

- [ ] I have fully tested all of the added features
- [ ] I have fully documented all of the relevant code

#### Additional Notes
<!-- Add any other information you think is relevant -->
