### PR TITLE
fix: 🩹 Add open source Calibri fallback

### DIFF
--- a/themes/radial/rules.typ
+++ b/themes/radial/rules.typ
@@ -2,7 +2,7 @@
 #import "./colors.typ": *
 
 #let rules(doc) = {
-  set text(font: "Calibri", size: 11pt)
+  set text(font: ("Calibri", "Carlito"), size: 11pt)
   set page("us-letter")
 
   set footnote.entry(separator: none)


### PR DESCRIPTION
see: https://wiki.debian.org/SubstitutingCalibriAndCambriaFonts

#### Summary
<!-- Provide a brief summary on the pull request -->

I can't for the life of me find a good way to install Calibri for the quick start template, but I can install Carlito rather easily.
Carlito is supposed to be roughly equivalent to Calibri.

#### Checklist

- [ ] I have fully tested all of the added features
- [ ] I have fully documented all of the relevant code

#### Additional Notes
<!-- Add any other information you think is relevant -->
