### PR TITLE
🐛 Fix package script

### DIFF
--- a/scripts/package
+++ b/scripts/package
@@ -16,6 +16,7 @@ files=(
   packages.typ
   internals.typ
   themes/
+  utils/
   typst.toml
   LICENSE
   README.md


### PR DESCRIPTION
#### Summary
the package script was missing the `utils/` folder so compiling `main.typ` was giving me a module not found error, adding the `utils/` folder to the script fixed this

#### Checklist

- [x] I have fully tested all of the added features
- [ ] I have fully documented all of the relevant code (N/A)

#### Additional Notes
<!-- Add any other information you think is relevant -->
